### PR TITLE
update for mynewt 1.7.0

### DIFF
--- a/hw/bsp/nrf52832_mdk/syscfg.yml
+++ b/hw/bsp/nrf52832_mdk/syscfg.yml
@@ -23,67 +23,23 @@ syscfg.defs:
         description: 'Set to indicate that BSP has NRF52'
         value: 1
 
-    UART_0:
-        description: 'Whether to enable UART0'
-        value:  1
-    UART_0_PIN_TX:
-        description: 'TX pin for UART0'
-        value:  20
-    UART_0_PIN_RX:
-        description: 'RX pin for UART0'
-        value:  19
-    UART_0_PIN_RTS:
-        description: 'RTS pin for UART0'
-        value:  5
-    UART_0_PIN_CTS:
-        description: 'CTS pin for UART0'
-        value: 7
-
-    UART_1:
-        description: 'Whether to enable bitbanger UART1'
-        value:  0
-    UART_1_PIN_TX:
-        description: 'TX pin for UART1'
-        value:  -1
-    UART_1_PIN_RX:
-        description: 'RX pin for UART1'
-        value:  -1
-
-    TIMER_0:
-        description: 'NRF52 Timer 0'
-        value:  1
-    TIMER_1:
-        description: 'NRF52 Timer 1'
-        value:  0
-    TIMER_2:
-        description: 'NRF52 Timer 2'
-        value:  0
-    TIMER_3:
-        description: 'NRF52 Timer 3'
-        value:  0
-    TIMER_4:
-        description: 'NRF52 Timer 4'
-        value:  0
-    TIMER_5:
-        description: 'NRF52 RTC 0'
-        value:  0
-
-syscfg.defs.BLE_LP_CLOCK:
-    TIMER_0:
-        value: 0
-    TIMER_5:
-        value: 1
-
 syscfg.vals:
+    MCU_TARGET: nrf52832
+    # Set default pins for peripherals
+    UART_0_PIN_TX: 20
+    UART_0_PIN_RX: 19
+
     CONFIG_FCB_FLASH_AREA: FLASH_AREA_NFFS
     REBOOT_LOG_FLASH_AREA: FLASH_AREA_REBOOT_LOG
     NFFS_FLASH_AREA: FLASH_AREA_NFFS
     COREDUMP_FLASH_AREA: FLASH_AREA_IMAGE_1
     MCU_DCDC_ENABLED: 1
-    XTAL_32768: 1
+    MCU_LFCLK_SOURCE: LFXO
     BOOT_SERIAL_DETECT_PIN: 13  # Button 1
 
-syscfg.vals.BLE_LP_CLOCK:
+syscfg.vals.BLE_CONTROLLER:
+    TIMER_0: 0
+    TIMER_5: 1
     OS_CPUTIME_FREQ: 32768
     OS_CPUTIME_TIMER_NUM: 5
     BLE_XTAL_SETTLE_TIME: 1500

--- a/repository.yml
+++ b/repository.yml
@@ -2,5 +2,5 @@ repo.name: mynewt_nrf52832_mdk
 repo.versions:
     "0.0.0": "master"
 
-    "0-latest": "master"
+    "0-latest": "0.0.0"     # master
     "0-dev": "0.0.0"        # master


### PR DESCRIPTION
Per https://github.com/apache/mynewt-newt/issues/297, floating versions can only point to fixed versions (which then may resolve to a branch).

Also updates settings to work with 1.7.0.